### PR TITLE
Fix BadRequest due to invalid epoch time

### DIFF
--- a/releases/unreleased/minimum-value-for-from_date-error.yml
+++ b/releases/unreleased/minimum-value-for-from_date-error.yml
@@ -1,0 +1,9 @@
+---
+title: Minimum value for 'from_date' error
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  EclipseFoundation API only allows to fetch identities
+  updated since the last year. The backend allowed dates
+  before that but the server raised BadRequest error.


### PR DESCRIPTION
The API only allows to fetch identities updated since the last year. The importer allowed to pass any date.