### PR TITLE
Ignore 5xx errors

### DIFF
--- a/releases/unreleased/5xx-errors-ignored.yml
+++ b/releases/unreleased/5xx-errors-ignored.yml
@@ -1,0 +1,9 @@
+---
+title: 5xx errors ignored
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The importer won't fail when 5xx errors are returned
+  by the server. These errors are normally due to invalid
+  identities stored in the platform.


### PR DESCRIPTION
These errors are normally raised on invalid identities stored in the platform.