### PR TITLE
Handle 5xx errors for every requests

### DIFF
--- a/releases/unreleased/handle-5xx-errors-on-every-request.yml
+++ b/releases/unreleased/handle-5xx-errors-on-every-request.yml
@@ -1,0 +1,9 @@
+---
+title: 5xx errors handled for every request
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  Errors were only handled when profiles were fetched
+  and not in other cases.
+


### PR DESCRIPTION
HTTP 5xx errors were only handle when fetching profile data. With this change, these errors are handle for every HTTP request.